### PR TITLE
SPARE and SPACE circuit PanelSchedule change

### DIFF
--- a/CS/Snoop/CollectorExts/CollectorExtElement.cs
+++ b/CS/Snoop/CollectorExts/CollectorExtElement.cs
@@ -2925,7 +2925,11 @@ namespace RevitLookup.Snoop.CollectorExts
       data.Add( new Snoop.Data.Object( "Base equipment", mepSys.BaseEquipment ) );
       data.Add( new Snoop.Data.Object( "Base equipment connector", mepSys.BaseEquipmentConnector ) );
       data.Add( new Snoop.Data.Object( "Connector manager", mepSys.ConnectorManager ) );
-      data.Add( new Snoop.Data.Enumerable( "Elements", mepSys.Elements ) );
+      
+      if ( !((BuiltInCategory)(mepSys.Category.Id.IntegerValue) == BuiltInCategory.OST_ElectricalInternalCircuits))
+      {
+		    data.Add( new Snoop.Data.Enumerable( "Elements", mepSys.Elements ) );
+      }
 
       ElectricalSystem elecSys = mepSys as ElectricalSystem;
       if( elecSys != null )


### PR DESCRIPTION
The issue is that if one tries to snoop current selection while selecting a "spare" or "space" circuit in a panel schedule the application throws an error because get_elements() cannot be called on category BuiltInCategory.OST_ElectricalInternalCircuits. 

The workaround here is to check if the object category is OST_ElectricalInternalCircuits; if it is then don't try to add Elements because you can't, if it isn't then add elements.